### PR TITLE
fix a few typsetting problems

### DIFF
--- a/_posts/2024-06-13-Eliciting-priors-from-LLMs-by-Gibbs-Sampling.md
+++ b/_posts/2024-06-13-Eliciting-priors-from-LLMs-by-Gibbs-Sampling.md
@@ -4,7 +4,9 @@ date: 2024-06-13
 tags: llm statistics gpt4
 ---
 
-In a recent pre-print, Zhu and Griffith describe  a method for [Eliciting the Priors of Large Language Models using Iterated In-Context Learning](https://arxiv.org/abs/2406.01860).  The core idea is to adapt a procedure used to perform [Markov Chain Monte Carlo with People](https://cocosci.princeton.edu/tom/papers/mcmcpeople.pdf). Effectively, this implements a Gibbs sampler for the joint distribution *p(d, h) = p(d|h)p(h)*, and the stationary distribution on hypotheses is the prior *p(h)*.  Samples from the prior are obtained by running the iterated learning process long enough to converge to the distribution. **Let's replicate their result and compare to direct sampling...**
+In a recent pre-print, Zhu and Griffith describe  a method for [Eliciting the Priors of Large Language Models using Iterated In-Context Learning](https://arxiv.org/abs/2406.01860).  The core idea is to adapt a procedure used to perform [Markov Chain Monte Carlo with People](https://cocosci.princeton.edu/tom/papers/mcmcpeople.pdf). Effectively, this implements a [Gibbs sampler](https://en.wikipedia.org/wiki/Gibbs_sampling) for the joint distribution `p(d, h) = p(d|h)p(h)`, and the stationary distribution on hypotheses is the prior `p(h)`.  Samples from the prior are obtained by running the iterated learning process long enough to converge to the distribution. **Let's replicate their result and compare to direct sampling...**
+
+# Background
 
 They depict their method  schematically as follows:
 
@@ -12,11 +14,11 @@ They depict their method  schematically as follows:
 
 The authors describe their method as:
 
-*To test the hypothesis that iterated in-context learning should reveal the prior distributions of LLMs, we incorporated GPT-4  into a prompt-based iterated learning procedure. At each iteration t, GPT-4 undertakes a prediction task using the data d_{t-1}. The model's prediction is recorded as ht. Subsequently, we employ generic likelihood functions that are a reasonable match for the sampling process producing the described data to randomly generate the data for the next iteration, dt ~ p(d|ht). For instance, we applied the method depicted in Figure 1 to investigate GPT-4's prior beliefs about men's lifespans. In this procedure, the LLM is prompted to estimate the lifespan of a random man, given information about his current age. The age of the man encountered in the next prompt is then uniformly sampled from a range extending from 1 to the lifespan predicted in the previous iteration, matching the probability of randomly encountering the man at this point in his life. By iteratively applying this procedure, we expect the final prediction made by GPT-4 will converge on a stationary distribution that reflects the model's prior beliefs about human life expectancy.*
+*To test the hypothesis that iterated in-context learning should reveal the prior distributions of LLMs, we incorporated GPT-4  into a prompt-based iterated learning procedure. At each iteration t, GPT-4 undertakes a prediction task using the data d_{t-1}. The model's prediction is recorded as ht. Subsequently, we employ generic likelihood functions that are a reasonable match for the sampling process producing the described data to randomly generate the data for the next iteration, `dt ~ p(d|ht)`. For instance, we applied the method depicted in Figure 1 to investigate GPT-4's prior beliefs about men's lifespans. In this procedure, the LLM is prompted to estimate the lifespan of a random man, given information about his current age. The age of the man encountered in the next prompt is then uniformly sampled from a range extending from 1 to the lifespan predicted in the previous iteration, matching the probability of randomly encountering the man at this point in his life. By iteratively applying this procedure, we expect the final prediction made by GPT-4 will converge on a stationary distribution that reflects the model's prior beliefs about human life expectancy.*
 
 *In the experiments presented in the remainder of the paper, 100 iterated learning chains were implemented with random seeds. We conducted 12 iterations for each chain. The temperature of GPT-4 was fixed at 1, consistent with the idea of sampling from the posterior.*
 
-## Implementation
+# Implementation
 
 The life expectancy example seems a bit morbid, so for more whimsy, we will use their cake-baking example, [using the prompt text from Appendix A ](https://arxiv.org/pdf/2406.01860). The general strategy is to define an [LLMFunction](http://reference.wolfram.com/language/ref/LLMFunction.html) that performs the iteration, and then a sampling function that generates the next iteration in the chain:
 
@@ -73,7 +75,7 @@ Interestingly, the resulting distribution appears different from Figure 5f, whic
 
 ![1kso4syalqxd1](/blog/images/2024/6/13/1kso4syalqxd1.png)
 
-## Comparison to GPT-4-turbo
+# Comparison to GPT-4-turbo
 
 The authors say they use GPT-4 without specifying a particular model.  So maybe we should see how this compares to our old workhorse, GPT-4-turbo? 
 
@@ -114,7 +116,7 @@ CountsBy[IntegerQ]@%%
 (*<|False -> 100|>*)
 ```
 
-## Comparison to Direct Sampling
+# Comparison to Direct Sampling
 
 Why not just perform direct sampling approach? The authors did not do this... I will take the conservative strategy of rewriting their prompt, deleting the prior information and mostly keeping everything else the same (except to specify that the total time should be in minutes):
 
@@ -148,7 +150,7 @@ Histogram[%, Automatic, "PDF"]
 
 ![18truyc0uwurz](/blog/images/2024/6/13/18truyc0uwurz.png)
 
-Now one might quibble that we have only done 100 evaluations, whereas the Gibbs sampling approach performed 1200 evaluations.  Maybe we are just not sampling enough to see a good distribution?  What if we make the same number of function calls? It turns out that the result is effectively same:
+Now one might quibble that we have only done 100 evaluations, whereas the Gibbs sampling approach performed 1200 evaluations.  Maybe we are just not sampling enough to see a good distribution?  What if we make the same number of function calls? It turns out that the result is effectively same as the 100 sample case, so this does not make a difference:
 
 ```mathematica
 result4 = ParallelTable[
@@ -160,11 +162,14 @@ Histogram[%, Automatic, "PDF"]
 
 ![1r24ljyf027q4](/blog/images/2024/6/13/1r24ljyf027q4.png)
 
-## Conclusions
+# Conclusions
 
 - In addition to predicting quantities (as done above), they also demonstrate applications to causal learning and proportion estimation.  It may be fun to apply this to problems we care about.
 
 - It is surprising that the prior distributions differ so much between GPT-4o and GPT-4-turbo.  
+
+- Future work:
+     - Apply to the German Tank problem?
 
 ```mathematica
 ToJekyll["Eliciting priors from LLMs by Gibbs Sampling", "llm statistics gpt4"]


### PR DESCRIPTION
Jekyll doesn't like text with | inside and turns these into tables